### PR TITLE
Add weight-based shipping module

### DIFF
--- a/_posts/2025-01-05-weight-based-free-shipping.md
+++ b/_posts/2025-01-05-weight-based-free-shipping.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: Weight-Based Free Shipping Example
+category: Tutorial
+thumbnail: 
+author: OpenMage Team
+permalink: /:year/:month/:day/:title:output_ext
+lang: en
+show_in_blog_page_last_posts_section: yes
+---
+
+This tutorial explains how to create a custom shipping method in OpenMage that grants free shipping when the order total exceeds **100&nbsp;€** and the total cart weight does not exceed **10&nbsp;kg**.
+
+## 1. Create a custom shipping module
+
+1. Create a new module with the structure:
+   `app/code/local/Gone/Shipping`
+2. Define `config.xml` to register the carrier model and system settings.
+3. Provide a carrier model extending `Mage_Shipping_Model_Carrier_Abstract`.
+
+## 2. Implement the carrier logic
+
+In the carrier model's `collectRates` method (see `app/code/local/Gone/Shipping` in this repository for a full example):
+
+```php
+public function collectRates(Mage_Shipping_Model_Rate_Request $request)
+{
+    if (!$this->getConfigData('active')) {
+        return false;
+    }
+
+    $result = Mage::getModel('shipping/rate_result');
+
+    $orderTotal = $request->getPackageValueWithDiscount();
+    $packageWeight = $request->getPackageWeight();
+
+    if ($orderTotal >= 100 && $packageWeight <= 10) {
+        $method = Mage::getModel('shipping/rate_result_method');
+        $method->setCarrier($this->_code);
+        $method->setCarrierTitle($this->getConfigData('title'));
+        $method->setMethod('standard');
+        $method->setMethodTitle($this->getConfigData('name'));
+        $method->setPrice(0);
+        $method->setCost(0);
+        $result->append($method);
+    }
+
+    return $result;
+}
+```
+
+## 3. Enable the shipping method
+
+After installing the module, enable it from **System → Configuration → Shipping Methods**. There you can configure the free shipping threshold and the maximum allowed cart weight.
+
+This simple example shows how to tailor shipping logic to business needs. You can extend it further with more complex conditions or additional shipping options.

--- a/app/code/local/Gone/Shipping/Model/Carrier/Gone.php
+++ b/app/code/local/Gone/Shipping/Model/Carrier/Gone.php
@@ -1,0 +1,41 @@
+<?php
+class Gone_Shipping_Model_Carrier_Gone
+    extends Mage_Shipping_Model_Carrier_Abstract
+    implements Mage_Shipping_Model_Carrier_Interface
+{
+    protected $_code = 'gone';
+
+    public function collectRates(Mage_Shipping_Model_Rate_Request $request)
+    {
+        if (!$this->getConfigFlag('active')) {
+            return false;
+        }
+
+        $result = Mage::getModel('shipping/rate_result');
+
+        $orderTotal = $request->getPackageValueWithDiscount();
+        $packageWeight = $request->getPackageWeight();
+
+        $threshold = (float)$this->getConfigData('free_threshold');
+        $weightLimit = (float)$this->getConfigData('weight_limit');
+
+        if ($orderTotal >= $threshold && $packageWeight <= $weightLimit) {
+            $method = Mage::getModel('shipping/rate_result_method');
+            $method->setCarrier($this->_code);
+            $method->setCarrierTitle($this->getConfigData('title'));
+            $method->setMethod('standard');
+            $method->setMethodTitle($this->getConfigData('name'));
+            $method->setPrice(0);
+            $method->setCost(0);
+            $result->append($method);
+        }
+
+        return $result;
+    }
+
+    public function getAllowedMethods()
+    {
+        return array('standard' => $this->getConfigData('name'));
+    }
+}
+

--- a/app/code/local/Gone/Shipping/etc/config.xml
+++ b/app/code/local/Gone/Shipping/etc/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<config>
+    <modules>
+        <Gone_Shipping>
+            <version>0.1.0</version>
+        </Gone_Shipping>
+    </modules>
+    <global>
+        <models>
+            <gone_shipping>
+                <class>Gone_Shipping_Model</class>
+            </gone_shipping>
+        </models>
+    </global>
+    <default>
+        <carriers>
+            <gone>
+                <active>1</active>
+                <title>Gone Shipping</title>
+                <name>Standard</name>
+                <free_threshold>100</free_threshold>
+                <weight_limit>10</weight_limit>
+            </gone>
+        </carriers>
+    </default>
+</config>

--- a/app/code/local/Gone/Shipping/etc/system.xml
+++ b/app/code/local/Gone/Shipping/etc/system.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<config>
+    <sections>
+        <carriers>
+            <groups>
+                <gone translate="label">
+                    <label>Gone Shipping</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>0</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <active translate="label">
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </active>
+                        <title translate="label">
+                            <label>Title</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </title>
+                        <name translate="label">
+                            <label>Method Name</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </name>
+                        <free_threshold translate="label">
+                            <label>Free Shipping From (€)</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </free_threshold>
+                        <weight_limit translate="label">
+                            <label>Maximum Weight (kg)</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </weight_limit>
+                    </fields>
+                </gone>
+            </groups>
+        </carriers>
+    </sections>
+</config>
+

--- a/app/etc/modules/Gone_Shipping.xml
+++ b/app/etc/modules/Gone_Shipping.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config>
+    <modules>
+        <Gone_Shipping>
+            <active>true</active>
+            <codePool>local</codePool>
+        </Gone_Shipping>
+    </modules>
+</config>


### PR DESCRIPTION
## Summary
- implement `Gone_Shipping` module providing free shipping when order total is at least 100€ and weight does not exceed 10 kg
- update tutorial post with module path and configuration notes

## Testing
- `bundle exec jekyll build` *(fails: rbenv version `3.1` is not installed)*